### PR TITLE
Fix docstring typo

### DIFF
--- a/scripts/dicom_metadata/dicom_metadata_to_json.py
+++ b/scripts/dicom_metadata/dicom_metadata_to_json.py
@@ -14,7 +14,7 @@ from oncodata.get_slice_count import get_slice_count
 def get_dicom_metadata_and_slice_counts(dicom_path):
     """Gets DICOM metadata and slice counts.
 
-    Argumuments:
+    Arguments:
         dicom_path(str): Path to a DICOM file.
     Returns:
         A dictionary containing the DICOM path,


### PR DESCRIPTION
## Summary
- fix a typo in `dicom_metadata_to_json.py`

## Testing
- `pytest -q` *(fails: cannot import name 'imread' from 'scipy.misc')*

------
https://chatgpt.com/codex/tasks/task_b_6880bbba21008329b1b033f11a113b5d